### PR TITLE
Update Gemspec Homepage Link

### DIFF
--- a/captainslog.gemspec
+++ b/captainslog.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['John Thomas Marino']
   s.email       = 'writejm@gmail.com'
-  s.homepage    = 'http://github.com/johnnytommy/captainslog'
+  s.homepage    = 'https://github.com/jt/captainslog'
   s.summary     = 'captainslog formats git logs by day and author'
   s.description = %q{
     captainslog is a command line utility that prints git logs by day and by author. This is useful when filling out time logs and emailing summaries of commits to clients.


### PR DESCRIPTION
I always have trouble finding the source code, because Rubygems.org uses the `homepage` field to link to the repo. This fixes that issue.

I love this gem and use it often! Thanks for building it.